### PR TITLE
Add role-based access control and user role migration

### DIFF
--- a/apps/backend/migration/src/columns.rs
+++ b/apps/backend/migration/src/columns.rs
@@ -33,6 +33,7 @@ pub enum User {
     Table,
     Id,
     Name,
+    Role,
 }
 
 #[derive(DeriveIden)]

--- a/apps/backend/migration/src/lib.rs
+++ b/apps/backend/migration/src/lib.rs
@@ -3,6 +3,8 @@ pub use sea_orm_migration::prelude::*;
 mod columns;
 mod m20250505_051849_create_users;
 mod m20250506_100520_create_identity_links;
+mod m20250601_000000_add_user_role;
+// mod m20250524_000000_create_updated_at_trigger;
 
 pub struct Migrator;
 
@@ -12,6 +14,8 @@ impl MigratorTrait for Migrator {
         vec![
             Box::new(m20250505_051849_create_users::Migration),
             Box::new(m20250506_100520_create_identity_links::Migration),
+            Box::new(m20250601_000000_add_user_role::Migration),
+            // Box::new(m20250524_000000_create_updated_at_trigger::Migration),
         ]
     }
 }

--- a/apps/backend/migration/src/m20250524_000000_create_updated_at_trigger.rs
+++ b/apps/backend/migration/src/m20250524_000000_create_updated_at_trigger.rs
@@ -1,0 +1,74 @@
+use sea_orm_migration::{prelude::*, schema::*};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // トリガー関数を作成
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                CREATE OR REPLACE FUNCTION update_updated_at_column()
+                RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.updated_at = CURRENT_TIMESTAMP;
+                    RETURN NEW;
+                END;
+                $$ language 'plpgsql';
+                "#,
+            )
+            .await?;
+
+        // usersテーブルにトリガーを追加
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                CREATE TRIGGER update_users_updated_at 
+                BEFORE UPDATE ON users 
+                FOR EACH ROW 
+                EXECUTE FUNCTION update_updated_at_column();
+                "#,
+            )
+            .await?;
+
+        // identity_linksテーブルにトリガーを追加
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                CREATE TRIGGER update_identity_links_updated_at 
+                BEFORE UPDATE ON identity_links 
+                FOR EACH ROW 
+                EXECUTE FUNCTION update_updated_at_column();
+                "#,
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // トリガーを削除
+        manager
+            .get_connection()
+            .execute_unprepared("DROP TRIGGER IF EXISTS update_users_updated_at ON users")
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared("DROP TRIGGER IF EXISTS update_identity_links_updated_at ON identity_links")
+            .await?;
+
+        // トリガー関数を削除
+        manager
+            .get_connection()
+            .execute_unprepared("DROP FUNCTION IF EXISTS update_updated_at_column()")
+            .await?;
+
+        Ok(())
+    }
+}

--- a/apps/backend/migration/src/m20250601_000000_add_user_role.rs
+++ b/apps/backend/migration/src/m20250601_000000_add_user_role.rs
@@ -1,0 +1,31 @@
+use sea_orm_migration::{prelude::*, schema::*};
+
+use crate::columns::User;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(User::Table)
+                    .add_column(string_null(User::Role).default("user"))
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(User::Table)
+                    .drop_column(User::Role)
+                    .to_owned(),
+            )
+            .await
+    }
+}

--- a/apps/backend/src/application/dtos/user_dto.rs
+++ b/apps/backend/src/application/dtos/user_dto.rs
@@ -1,5 +1,6 @@
 use crate::{
     domain::entities::user::User,
+    domain::enums::user_role::UserRole,
     presentation::graphql::types::user_type::{CreateUserInput, UpdateUserInput},
 };
 use chrono::{DateTime, Utc};
@@ -12,6 +13,7 @@ use super::identity_link_dto::IdentityLinkDto;
 pub struct UserDTO {
     pub id: Uuid,
     pub name: String,
+    pub role: UserRole,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub identity_links: Vec<IdentityLinkDto>,
@@ -22,6 +24,7 @@ impl From<User> for UserDTO {
         Self {
             id: user.id,
             name: user.name,
+            role: user.role,
             created_at: user.created_at,
             updated_at: user.updated_at,
             identity_links: user.identity_links.into_iter().map(IdentityLinkDto::from).collect(),

--- a/apps/backend/src/application/dtos/user_dto.rs
+++ b/apps/backend/src/application/dtos/user_dto.rs
@@ -27,7 +27,11 @@ impl From<User> for UserDTO {
             role: user.role,
             created_at: user.created_at,
             updated_at: user.updated_at,
-            identity_links: user.identity_links.into_iter().map(IdentityLinkDto::from).collect(),
+            identity_links: user
+                .identity_links
+                .into_iter()
+                .map(IdentityLinkDto::from)
+                .collect(),
         }
     }
 }

--- a/apps/backend/src/application/usecases/sign_up.rs
+++ b/apps/backend/src/application/usecases/sign_up.rs
@@ -110,6 +110,7 @@ mod tests {
         User {
             id: Uuid::new_v4(),
             name: "Test User".to_string(),
+            role: crate::domain::enums::user_role::UserRole::User,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
             identity_links: Vec::new(),

--- a/apps/backend/src/domain/entities/user.rs
+++ b/apps/backend/src/domain/entities/user.rs
@@ -18,7 +18,10 @@ pub struct NewUser {
 
 impl From<SignUpInputDTO> for NewUser {
     fn from(input: SignUpInputDTO) -> Self {
-        Self { name: input.name }
+        Self {
+            name: input.name,
+            role: UserRole::default(), // Default to User role for new signups
+        }
     }
 }
 
@@ -27,6 +30,7 @@ impl From<NewUser> for user::ActiveModel {
         user::ActiveModel {
             id: ActiveValue::NotSet,
             name: ActiveValue::Set(user.name),
+            role: ActiveValue::Set(user.role.to_string()),
             ..Default::default()
         }
     }
@@ -36,6 +40,7 @@ impl From<NewUser> for user::ActiveModel {
 pub struct User {
     pub id: Uuid,
     pub name: String,
+    pub role: UserRole,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub identity_links: Vec<IdentityLink>,
@@ -43,7 +48,10 @@ pub struct User {
 
 impl From<CreateUserDto> for NewUser {
     fn from(input: CreateUserDto) -> Self {
-        Self { name: input.name }
+        Self {
+            name: input.name,
+            role: UserRole::default(), // Default to User role for new users
+        }
     }
 }
 
@@ -52,6 +60,7 @@ impl From<User> for user::ActiveModel {
         user::ActiveModel {
             id: ActiveValue::Set(user.id),
             name: ActiveValue::Set(user.name.clone()),
+            role: ActiveValue::Set(user.role.to_string()),
             ..Default::default()
         }
     }

--- a/apps/backend/src/infrastructure/database/models/user.rs
+++ b/apps/backend/src/infrastructure/database/models/user.rs
@@ -1,17 +1,19 @@
 use chrono::{DateTime, Utc};
 use sea_orm::entity::prelude::*;
-use uuid::Uuid; // Add this line
+use uuid::Uuid;
 
 use crate::domain::entities::user::User;
+use crate::domain::enums::user_role::UserRole;
 
 use super::identity_link;
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
 #[sea_orm(table_name = "users")]
 pub struct Model {
-    #[sea_orm(primary_key, auto_increment = false)] // Set auto_increment to false
-    pub id: Uuid, // Changed from i32
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: Uuid,
     pub name: String,
+    pub role: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -42,6 +44,7 @@ impl From<Model> for User {
         Self {
             id: model.id,
             name: model.name,
+            role: UserRole::from(model.role),
             created_at: model.created_at,
             updated_at: model.updated_at,
             identity_links: vec![],

--- a/apps/backend/src/presentation/graphql/guards/authorization.rs
+++ b/apps/backend/src/presentation/graphql/guards/authorization.rs
@@ -1,17 +1,11 @@
 use async_graphql::{Context, ErrorExtensions, Guard, Result as GraphQLResult};
 
+use crate::domain::enums::user_role::UserRole;
 use crate::presentation::graphql::context::UserContext;
 
 // Role-based authorization guard
 pub struct RoleGuard {
     pub required_role: UserRole,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub enum UserRole {
-    User,
-    Admin,
-    SuperAdmin,
 }
 
 impl RoleGuard {
@@ -23,34 +17,26 @@ impl RoleGuard {
         Self::new(UserRole::Admin)
     }
 
-    pub fn super_admin() -> Self {
-        Self::new(UserRole::SuperAdmin)
-    }
-
     pub fn user() -> Self {
         Self::new(UserRole::User)
     }
 }
 
-#[async_graphql::async_trait]
 impl Guard for RoleGuard {
     async fn check(&self, ctx: &Context<'_>) -> GraphQLResult<()> {
         let user_context = ctx
             .data::<UserContext>()
-            .map_err(|_| "Authentication required".extend())?;
+            .map_err(|_| "Authentication required".extend_with(|_, e| e.set("code", "AUTH_REQUIRED")))?;
 
         if let Some(user) = &user_context.user {
-            // For now, we'll implement basic role checking
-            // In a real application, you'd store roles in the database
-            let user_role = determine_user_role(&user.id).await;
-
-            if has_sufficient_role(&user_role, &self.required_role) {
+            // Use the role from the current user context
+            if has_sufficient_role(&user.role, &self.required_role) {
                 Ok(())
             } else {
-                Err("Insufficient permissions".extend())
+                Err("Insufficient permissions".extend_with(|_, e| e.set("code", "INSUFFICIENT_PERMISSIONS")))
             }
         } else {
-            Err("Authentication required".extend())
+            Err("Authentication required".extend_with(|_, e| e.set("code", "AUTH_REQUIRED")))
         }
     }
 }
@@ -58,66 +44,27 @@ impl Guard for RoleGuard {
 // Authentication guard (simpler - just checks if user is logged in)
 pub struct AuthenticationGuard;
 
-#[async_graphql::async_trait]
 impl Guard for AuthenticationGuard {
     async fn check(&self, ctx: &Context<'_>) -> GraphQLResult<()> {
         let user_context = ctx
             .data::<UserContext>()
-            .map_err(|_| "Authentication required".extend())?;
+            .map_err(|_| "Authentication required".extend_with(|_, e| e.set("code", "AUTH_REQUIRED")))?;
 
         if user_context.user.is_some() {
             Ok(())
         } else {
-            Err("Authentication required".extend())
+            Err("Authentication required".extend_with(|_, e| e.set("code", "AUTH_REQUIRED")))
         }
     }
 }
 
 // Helper functions
-async fn determine_user_role(user_id: &uuid::Uuid) -> UserRole {
-    // TODO: Implement actual role lookup from database
-    // For now, return User role as default
-    UserRole::User
-}
-
 fn has_sufficient_role(user_role: &UserRole, required_role: &UserRole) -> bool {
     use UserRole::*;
 
     match (user_role, required_role) {
-        (SuperAdmin, _) => true,
-        (Admin, Admin) | (Admin, User) => true,
-        (User, User) => true,
+        (Admin, _) => true,  // Admin can access everything
+        (User, User) => true, // User can access user-level resources
         _ => false,
-    }
-}
-
-// Resource ownership guard - checks if user owns the resource
-pub struct ResourceOwnershipGuard {
-    pub resource_user_id_field: String,
-}
-
-impl ResourceOwnershipGuard {
-    pub fn new(resource_user_id_field: &str) -> Self {
-        Self {
-            resource_user_id_field: resource_user_id_field.to_string(),
-        }
-    }
-}
-
-#[async_graphql::async_trait]
-impl Guard for ResourceOwnershipGuard {
-    async fn check(&self, ctx: &Context<'_>) -> GraphQLResult<()> {
-        let user_context = ctx
-            .data::<UserContext>()
-            .map_err(|_| "Authentication required".extend())?;
-
-        if let Some(current_user) = &user_context.user {
-            // TODO: Implement resource ownership checking
-            // This would involve looking up the resource and comparing user IDs
-            // For now, we'll just ensure the user is authenticated
-            Ok(())
-        } else {
-            Err("Authentication required".extend())
-        }
     }
 }

--- a/apps/backend/src/presentation/graphql/mod.rs
+++ b/apps/backend/src/presentation/graphql/mod.rs
@@ -1,4 +1,5 @@
 pub mod context;
+pub mod guards;
 pub mod mutations;
 pub mod resolvers;
 pub mod scalars;

--- a/apps/backend/src/presentation/graphql/schema.rs
+++ b/apps/backend/src/presentation/graphql/schema.rs
@@ -12,6 +12,12 @@ pub struct QueryRoot {
     // 他のクエリをここに追加
 }
 
+impl QueryRoot {
+    pub fn new(user_resolver: UserResolver) -> Self {
+        Self { user_resolver }
+    }
+}
+
 #[async_graphql::Object]
 impl QueryRoot {
     // ユーザークエリへのアクセスを提供
@@ -25,6 +31,15 @@ pub struct MutationRoot {
     authentication_mutation: AuthenticationMutation,
     user_mutation: UserMutation,
     // 他のミューテーションをここに追加
+}
+
+impl MutationRoot {
+    pub fn new(authentication_mutation: AuthenticationMutation, user_mutation: UserMutation) -> Self {
+        Self {
+            authentication_mutation,
+            user_mutation,
+        }
+    }
 }
 
 #[async_graphql::Object]
@@ -68,11 +83,8 @@ pub fn build_schema(use_cases: &UseCases, services: &Services) -> AppSchema {
     );
 
     Schema::build(
-        QueryRoot { user_resolver },
-        MutationRoot {
-            user_mutation,
-            authentication_mutation,
-        },
+        QueryRoot::new(user_resolver),
+        MutationRoot::new(authentication_mutation, user_mutation),
         EmptySubscription,
     )
     .finish()

--- a/apps/backend/src/presentation/graphql/types/user_type.rs
+++ b/apps/backend/src/presentation/graphql/types/user_type.rs
@@ -9,6 +9,7 @@ use crate::presentation::graphql::types::identity_link_type::IdentityLink;
 pub struct User {
     pub id: Uuid,
     pub name: String,
+    pub role: String, // Convert UserRole to String for GraphQL
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub identity_links: Vec<IdentityLink>,
@@ -19,9 +20,14 @@ impl From<UserDTO> for User {
         Self {
             id: user.id,
             name: user.name,
+            role: user.role.to_string(),
             created_at: user.created_at,
             updated_at: user.updated_at,
-            identity_links: user.identity_links.into_iter().map(IdentityLink::from).collect(),
+            identity_links: user
+                .identity_links
+                .into_iter()
+                .map(IdentityLink::from)
+                .collect(),
         }
     }
 }

--- a/apps/backend/tests/authorization_test.rs
+++ b/apps/backend/tests/authorization_test.rs
@@ -1,0 +1,108 @@
+// filepath: /workspace/morrow/apps/backend/tests/authorization_test.rs
+    use async_graphql::{Schema, EmptyMutation, EmptySubscription, Object};
+    use backend::{
+        application::dtos::user_dto::UserDTO,
+        domain::enums::user_role::UserRole,
+        presentation::graphql::{
+            context::UserContext,
+            guards::{AuthenticationGuard, RoleGuard},
+        },
+    };
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    struct QueryRoot;
+
+    #[Object]
+    impl QueryRoot {
+        #[graphql(guard = "AuthenticationGuard")]
+        async fn protected_query(&self) -> String {
+            "This is protected content".to_string()
+        }
+
+        #[graphql(guard = "RoleGuard::admin()")]
+        async fn admin_only_query(&self) -> String {
+            "This is admin only content".to_string()
+        }
+    }
+
+    type TestSchema = Schema<QueryRoot, EmptyMutation, EmptySubscription>;
+
+    fn create_test_schema() -> TestSchema {
+        Schema::build(QueryRoot, EmptyMutation, EmptySubscription).finish()
+    }
+
+    fn create_user_context(role: UserRole) -> UserContext {
+        UserContext {
+            user: Some(UserDTO {
+                id: Uuid::new_v4(),
+                name: "Test User".to_string(),
+                role,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+                identity_links: Vec::new(),
+            }),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_authentication_guard_with_user() {
+        let schema = create_test_schema();
+        let user_context = create_user_context(UserRole::User);
+
+        let request = async_graphql::Request::new("{ protectedQuery }");
+        let response = schema
+            .execute(request.data(user_context))
+            .await;
+
+        assert!(response.errors.is_empty());
+        assert_eq!(
+            response.data.to_string(),
+            r#"{protectedQuery: "This is protected content"}"#
+        );
+    }
+
+    #[tokio::test]
+    async fn test_authentication_guard_without_user() {
+        let schema = create_test_schema();
+        let user_context = UserContext { user: None };
+
+        let request = async_graphql::Request::new("{ protectedQuery }");
+        let response = schema
+            .execute(request.data(user_context))
+            .await;
+
+        assert!(!response.errors.is_empty());
+        assert!(response.errors[0].message.contains("Authentication required"));
+    }
+
+    #[tokio::test]
+    async fn test_role_guard_admin_access() {
+        let schema = create_test_schema();
+        let admin_context = create_user_context(UserRole::Admin);
+
+        let request = async_graphql::Request::new("{ adminOnlyQuery }");
+        let response = schema
+            .execute(request.data(admin_context))
+            .await;
+
+        assert!(response.errors.is_empty());
+        assert_eq!(
+            response.data.to_string(),
+            r#"{adminOnlyQuery: "This is admin only content"}"#
+        );
+    }
+
+    #[tokio::test]
+    async fn test_role_guard_user_denied() {
+        let schema = create_test_schema();
+        let user_context = create_user_context(UserRole::User);
+
+        let request = async_graphql::Request::new("{ adminOnlyQuery }");
+        let response = schema
+            .execute(request.data(user_context))
+            .await;
+
+        assert!(!response.errors.is_empty());
+        assert!(response.errors[0].message.contains("Insufficient permissions"));
+    }

--- a/apps/backend/tests/integration/graphql_schema_test.rs
+++ b/apps/backend/tests/integration/graphql_schema_test.rs
@@ -163,11 +163,8 @@ mod tests {
 
         // Build schema
         Schema::build(
-            QueryRoot { user_resolver },
-            MutationRoot {
-                user_mutation,
-                authentication_mutation,
-            },
+            QueryRoot::new(user_resolver),
+            MutationRoot::new(authentication_mutation, user_mutation),
             EmptySubscription,
         )
         .finish()

--- a/apps/backend/tests/presentation/authentication_mutation_test.rs
+++ b/apps/backend/tests/presentation/authentication_mutation_test.rs
@@ -8,6 +8,7 @@ mod tests {
             identity_link::{IdentityLink, NewIdentityLink},
             user::{NewUser, User},
         },
+        enums::user_role::UserRole,
         repositories::{
             identity_link_repository::IdentityLinkRepository, user_repository::UserRepository,
         },
@@ -59,6 +60,7 @@ mod tests {
         User {
             id: Uuid::new_v4(),
             name: "Test User".to_string(),
+            role: UserRole::User,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
             identity_links: Vec::new(),


### PR DESCRIPTION
Introduce user role migration and update the database schema to support role-based access control. Implement GraphQL authorization guards to enforce role restrictions, and enhance user entities and models to accommodate the new role field. Update tests to ensure comprehensive coverage of authorization scenarios.